### PR TITLE
fix [-Wincompatible-pointer-types] with PHP 8

### DIFF
--- a/excimer_log.c
+++ b/excimer_log.c
@@ -408,10 +408,17 @@ static void excimer_log_array_incr(HashTable *ht, zend_string *sp_key, zend_long
 	}
 }
 
+#if PHP_VERSION_ID < 80000
 static int excimer_log_aggr_compare(const void *a, const void *b)
 {
 	zval *zp_a = &((Bucket*)a)->val;
 	zval *zp_b = &((Bucket*)b)->val;
+#else
+static int excimer_log_aggr_compare(Bucket *a, Bucket *b)
+{
+	zval *zp_a = &a->val;
+	zval *zp_b = &b->val;
+#endif
 
 	zval *zp_a_incl = zend_hash_str_find(Z_ARRVAL_P(zp_a), "inclusive", sizeof("inclusive")-1);
 	zval *zp_b_incl = zend_hash_str_find(Z_ARRVAL_P(zp_b), "inclusive", sizeof("inclusive")-1);


### PR DESCRIPTION
```
In file included from /opt/remi/php80/root/usr/include/php/Zend/zend.h:33,
                 from /opt/remi/php80/root/usr/include/php/main/php.h:31,
                 from /dev/shm/BUILD/php80-php-pecl-excimer-1.0.0/NTS/excimer_log.c:16:
/dev/shm/BUILD/php80-php-pecl-excimer-1.0.0/NTS/excimer_log.c: In function 'excimer_log_aggr_by_func':
/dev/shm/BUILD/php80-php-pecl-excimer-1.0.0/NTS/excimer_log.c:498:28: warning: passing argument 3 of 'zend_hash_sort_ex' from incompatible pointer type [-Wincompatible-pointer-types]
  498 |  zend_hash_sort(ht_result, excimer_log_aggr_compare, 0);
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~
      |                            |
      |                            int (*)(const void *, const void *)
/opt/remi/php80/root/usr/include/php/Zend/zend_hash.h:272:35: note: in definition of macro 'zend_hash_sort'
  272 |  zend_hash_sort_ex(ht, zend_sort, compare_func, renumber)
      |                                   ^~~~~~~~~~~~
/opt/remi/php80/root/usr/include/php/Zend/zend_hash.h:268:108: note: expected 'bucket_compare_func_t' {aka 'int (*)(struct _Bucket *, struct _Bucket *)'} but argument is of type 'int (*)(const void *, const void *)'
  268 | ZEND_API void  ZEND_FASTCALL zend_hash_sort_ex(HashTable *ht, sort_func_t sort_func, bucket_compare_func_t compare_func, zend_bool renumber);
      |                                                                                      ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~

```