### PR TITLE
fix arginfo for 7.1

### DIFF
--- a/excimer.c
+++ b/excimer.c
@@ -285,7 +285,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_ExcimerLog_formatCollapsed, 0)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID < 70200
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(arginfo_ExcimerLog_aggregateByFunction, IS_ARRAY, NULL, 0)
+#else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(arginfo_ExcimerLog_aggregateByFunction, IS_ARRAY, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_ExcimerLog_getEventCount, 0)


### PR DESCRIPTION
As package.xml claims 7.1 is minimal supported version.

Without this fix

```
PIC -DPIC -o .libs/excimer.o
/work/GIT/pecl-and-ext/excimer/excimer.c:288:89: erreur: la macro « ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO » requiert 4 arguments, mais seulement 3 ont été passés
  288 | ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(arginfo_ExcimerLog_aggregateByFunction, IS_ARRAY, 0)
      |                                                                                         ^
Dans le fichier inclus depuis /opt/remi/php71/root/usr/include/php/main/php.h:39,
                 depuis /work/GIT/pecl-and-ext/excimer/excimer.c:22:
/opt/remi/php71/root/usr/include/php/Zend/zend_API.h:112: note: macro "ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO" defined here
  112 | #define ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(name, type, class_name, allow_null) \
      | 
/opt/remi/php71/root/usr/include/php/Zend/zend_API.h:120:41: erreur: expected « = », « , », « ; », « asm » or « __attribute__ » before « } » token
  120 | #define ZEND_END_ARG_INFO()             };
      |                                         ^
/work/GIT/pecl-and-ext/excimer/excimer.c:289:1: note: dans l'expansion de la macro « ZEND_END_ARG_INFO »
  289 | ZEND_END_ARG_INFO()
      | ^~~~~~~~~~~~~~~~~
Dans le fichier inclus depuis /opt/remi/php71/root/usr/include/php/main/php.h:39,
                 depuis /work/GIT/pecl-and-ext/excimer/excimer.c:22:
/work/GIT/pecl-and-ext/excimer/excimer.c:391:49: erreur: « arginfo_ExcimerLog_aggregateByFunction » non déclaré ici (hors de toute fonction); vouliez-vous utiliser « zim_ExcimerLog_aggregateByFunction » ?
  391 |         PHP_ME(ExcimerLog, aggregateByFunction, arginfo_ExcimerLog_aggregateByFunction, 0)
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/remi/php71/root/usr/include/php/Zend/zend_API.h:70:77: note: dans la définition de la macro « ZEND_FENTRY »
   70 | #define ZEND_FENTRY(zend_name, name, arg_info, flags)   { #zend_name, name, arg_info, (uint32_t) (sizeof(arg_info)/sizeof(struct _zend_internal_arg_info)-1), flags },
      |                                                                             ^~~~~~~~
/opt/remi/php71/root/usr/include/php/main/php.h:363:25: note: dans l'expansion de la macro « ZEND_ME »
  363 | #define PHP_ME          ZEND_ME
      |                         ^~~~~~~
/work/GIT/pecl-and-ext/excimer/excimer.c:391:9: note: dans l'expansion de la macro « PHP_ME »
  391 |         PHP_ME(ExcimerLog, aggregateByFunction, arginfo_ExcimerLog_aggregateByFunction, 0)
      |         ^~~~~~

```

With this fix:


```
=====================================================================
PHP         : /opt/remi/php71/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 7.1.33
ZEND_VERSION: 3.1.0
PHP_OS      : Linux - Linux builder.remirepo.net 5.17.4-200.fc35.x86_64 #1 SMP PREEMPT Wed Apr 20 15:37:53 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/excimer/tmp-php.ini
More .INIs  :   
CWD         : /work/GIT/pecl-and-ext/excimer
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2022-05-04 16:20:53
=====================================================================
PASS ExcimerProfiler CPU profile [tests/cpu.phpt] 
PASS ExcimerProfiler max depth [tests/maxDepth.phpt] 
PASS ExcimerTimer periodic mode [tests/periodic.phpt] 
PASS ExcimerProfiler real time profile [tests/real.phpt] 
PASS excimer_set_timeout [tests/timeout.phpt] 
PASS ExcimerTimer [tests/timer.phpt] 
=====================================================================
TIME END 2022-05-04 16:21:03

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   15
---------------------------------------------------------------------

Number of tests :    6                 6
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :    6 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :   10 seconds
=====================================================================

```
Alternative is to bump minimal supported version to 7.2