### PR TITLE
Fix compatibility with PHP <= 7.3

### DIFF
--- a/excimer_log.c
+++ b/excimer_log.c
@@ -511,10 +511,19 @@ void excimer_log_get_speedscope_data(excimer_log *log, zval *zp_data) {
 		HashTable *ht_stack = excimer_log_new_array(num_frames);
 		zend_hash_extend(ht_stack, num_frames, 1);
 		ZEND_HASH_FILL_PACKED(ht_stack) {
+#if PHP_VERSION_ID < 70400
+			zval new_val;
+
+			ZVAL_LONG(&new_val, 0);
+			for (j = 0; j < num_frames; j++) {
+				ZEND_HASH_FILL_ADD(&new_val);
+			}
+#else
 			for (j = 0; j < num_frames; j++) {
 				ZEND_HASH_FILL_SET_LONG(0);
 				ZEND_HASH_FILL_NEXT();
 			}
+#endif
 		} ZEND_HASH_FILL_END();
 
 		/* Write the values in reverse order */


### PR DESCRIPTION
As package.xml states this extension is compatible with PHP >= 7.1

`ZEND_HASH_FILL_SET_LONG` was introduce in 7.4

Without this patch

Build:

```
/builddir/build/BUILD/php-pecl-excimer-1.1.0/ZTS/excimer_log.c: In function 'excimer_log_get_speedscope_data':
/builddir/build/BUILD/php-pecl-excimer-1.1.0/ZTS/excimer_log.c:515:5: warning: implicit declaration of function 'ZEND_HASH_FILL_SET_LONG'; did you mean 'ZEND_HASH_FILL_END'? [-Wimplicit-function-declaration]
     ZEND_HASH_FILL_SET_LONG(0);
     ^~~~~~~~~~~~~~~~~~~~~~~
     ZEND_HASH_FILL_END
/builddir/build/BUILD/php-pecl-excimer-1.1.0/ZTS/excimer_log.c:516:5: warning: implicit declaration of function 'ZEND_HASH_FILL_NEXT'; did you mean 'ZEND_HASH_FILL_END'? [-Wimplicit-function-declaration]
     ZEND_HASH_FILL_NEXT();
     ^~~~~~~~~~~~~~~~~~~
     ZEND_HASH_FILL_END
In file included from /usr/include/php-zts/php/Zend/zend.h:32,
                 from /usr/include/php-zts/php/main/php.h:33,
                 from /builddir/build/BUILD/php-pecl-excimer-1.1.0/ZTS/excimer_log.c:16:
/usr/include/php-zts/php/Zend/zend_hash.h:1055:11: warning: unused variable '__fill_bkt' [-Wunused-variable]
   Bucket *__fill_bkt = __fill_ht->arData + __fill_ht->nNumUsed; \
           ^~~~~~~~~~
/builddir/build/BUILD/php-pecl-excimer-1.1.0/ZTS/excimer_log.c:513:3: note: in expansion of macro 'ZEND_HASH_FILL_PACKED'
   ZEND_HASH_FILL_PACKED(ht_stack) {
   ^~~~~~~~~~~~~~~~~~~~~

```
Run:

```
PHP Warning:  PHP Startup: Unable to load dynamic library '/builddir/build/BUILDROOT/php-pecl-excimer-1.1.0-1.el8.remi.7.3.x86_64//usr/lib64/php/modules/excimer.so' (tried: /builddir/build/BUILDROOT/php-pecl-excimer-1.1.0-1.el8.remi.7.3.x86_64//usr/lib64/php/modules/excimer.so (/builddir/build/BUILDROOT/php-pecl-excimer-1.1.0-1.el8.remi.7.3.x86_64//usr/lib64/php/modules/excimer.so: undefined symbol: ZEND_HASH_FILL_SET_LONG), /usr/lib64/php/modules//builddir/build/BUILDROOT/php-pecl-excimer-1.1.0-1.el8.remi.7.3.x86_64//usr/lib64/php/modules/excimer.so.so (/usr/lib64/php/modules//builddir/build/BUILDROOT/php-pecl-excimer-1.1.0-1.el8.remi.7.3.x86_64//usr/lib64/php/modules/excimer.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
```

With this patch
```

=====================================================================
PHP         : /usr/bin/zts-php 
PHP_SAPI    : cli
PHP_VERSION : 7.1.33
ZEND_VERSION: 3.1.0
PHP_OS      : Linux - Linux builder.remirepo.net 6.1.14-200.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Sun Feb 26 00:13:26 UTC 2023 x86_64
INI actual  : /builddir/build/BUILD/php-pecl-excimer-1.1.0/ZTS
More .INIs  :   
CWD         : /builddir/build/BUILD/php-pecl-excimer-1.1.0/ZTS
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2023-03-03 07:33:16
=====================================================================
PASS ExcimerProfiler CPU profile [tests/cpu.phpt] 
PASS ExcimerProfiler max depth [tests/maxDepth.phpt] 
PASS ExcimerTimer periodic mode [tests/periodic.phpt] 
PASS ExcimerProfiler real time profile [tests/real.phpt] 
PASS excimer_set_timeout [tests/timeout.phpt] 
PASS ExcimerTimer [tests/timer.phpt] 
=====================================================================
TIME END 2023-03-03 07:33:25

```
