### PR TITLE
Fix OS dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -88,9 +88,7 @@
     <min>1.8.0</min>
    </pearinstaller>
    <os>
-    <name>linux</name>
-    <name>freebsd</name>
-    <name>darwin</name>
+    <name>unix</name>
    </os>
   </required>
  </dependencies>


### PR DESCRIPTION
Single name allowed
unix means 'linux', 'freebsd', 'darwin', 'sunos', 'irix', 'hpux', 'aix'