### PR TITLE
Fix ZTS: use timer->tls instead of thread-local excimer_timer_tls in handler

### DIFF
--- a/excimer_timer.c
+++ b/excimer_timer.c
@@ -41,9 +41,9 @@ static void excimer_timer_interrupt(zend_execute_data *execute_data);
  * Add a timer to the pending list. Unsynchronised, i.e. the caller is
  * responsible for locking the mutex if required.
  */
-static void excimer_timer_list_enqueue(excimer_timer *timer)
+static void excimer_timer_list_enqueue(excimer_timer *timer, excimer_timer_tls_t *tls)
 {
-	excimer_timer **head_pp = &excimer_timer_tls.pending_head;
+	excimer_timer **head_pp = &tls->pending_head;
 	if (!timer->pending_next) {
 		if (*head_pp) {
 			timer->pending_next = *head_pp;
@@ -259,10 +259,11 @@ void excimer_timer_destroy(excimer_timer *timer)
 static void excimer_timer_handle(void * data, int overrun_count)
 {
 	excimer_timer *timer = (excimer_timer*)data;
-	excimer_mutex_lock(&excimer_timer_tls.mutex);
+	excimer_timer_tls_t *tls = timer->tls;
+	excimer_mutex_lock(&tls->mutex);
 	timer->event_count += overrun_count + 1;
-	excimer_timer_list_enqueue(timer);
-	excimer_mutex_unlock(&excimer_timer_tls.mutex);
+	excimer_timer_list_enqueue(timer, tls);
+	excimer_mutex_unlock(&tls->mutex);
 	excimer_timer_atomic_bool_store(timer->vm_interrupt_ptr, 1);
 }
 


### PR DESCRIPTION
## Summary

- `excimer_timer_handle` runs on the timerlib handler thread, not the PHP thread. Under ZTS, `ZEND_TLS` gives each thread its own copy of `excimer_timer_tls`, so the handler was locking the wrong mutex and enqueuing into the wrong pending list — resulting in zero profiling samples.
- Use `timer->tls` (set during init on the PHP thread) instead of the bare `excimer_timer_tls` global, so the handler always writes to the owning PHP thread's data regardless of which thread it executes on.

## Context

Reported in [getsentry/sentry-laravel#1068](https://github.com/getsentry/sentry-laravel/issues/1068) — profiling produces no data when using FrankenPHP (which runs PHP in ZTS mode). Confirmed that excimer 1.2.3 works and 1.2.5 does not. The regression was introduced during the timerlib rewrite in 1.2.4.

## Test plan

- [x] All existing tests pass on NTS (`make test` — 12/12 passed)
- [ ] Verify profiling produces samples on a ZTS build (e.g. FrankenPHP) — this cannot be tested on NTS since `ZEND_TLS` expands to a plain global and the bug is invisible